### PR TITLE
kind-projector scala compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
         <scala.version>2.12.3</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <scala-maven-plugin.version>3.4.4</scala-maven-plugin.version>
+        <scala-maven-plugin.version>3.4.6</scala-maven-plugin.version>
         <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
         <scala.version>2.12.3</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <scala-maven-plugin.version>3.3.1</scala-maven-plugin.version>
+        <scala-maven-plugin.version>3.4.4</scala-maven-plugin.version>
         <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
 
 
@@ -170,6 +170,13 @@
                             <arg>-deprecation</arg>
                             <arg>-feature</arg>
                         </args>
+                        <compilerPlugins>
+                            <compilerPlugin>
+                                <groupId>org.spire-math</groupId>
+                                <artifactId>kind-projector_2.12</artifactId>
+                                <version>0.9.9</version>
+                            </compilerPlugin>
+                        </compilerPlugins>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <scala.version>2.12.3</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala-maven-plugin.version>3.4.6</scala-maven-plugin.version>
+        <kind-projector-compiler-plugin.version>0.9.9</kind-projector-compiler-plugin.version>
         <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
 
 
@@ -174,7 +175,7 @@
                             <compilerPlugin>
                                 <groupId>org.spire-math</groupId>
                                 <artifactId>kind-projector_2.12</artifactId>
-                                <version>0.9.9</version>
+                                <version>${kind-projector-compiler-plugin.version}</version>
                             </compilerPlugin>
                         </compilerPlugins>
                     </configuration>


### PR DESCRIPTION
Introducing the [`org.spire-math:kind-projector`](https://github.com/non/kind-projector) compiler plugin. This plugin allows us to write type lambdas more easy by using a syntactic sugar. For example:

Instead of:

```scala
private type ErrorOr[T] = Either[String, T] // defining type aliasses locally all over the place
xs.traverse[ErrorOr, Unit](f)
```

or even worse:

```scala
xs.traverse[({type L[A] = Either[String, A]})#L, Unit](f)
```

the `kind-projector` plugin allows us to write elegant syntax like:

```scala
xs.traverse[Either[String, ?], Unit](f)
```

Until now we have managed to avoid type lambdas completely in our code, but as I'm going to introduce [cats](https://github.com/typelevel/cats/) as a dependency in our code base, starting with a [current experiment in easy-split-multi-deposit](https://github.com/rvanheest-DANS-KNAW/easy-split-multi-deposit/tree/improve-error-handling), the use of type lambdas seems inevitable. Hence, adding it now to the parent projects seems the most logical step to start with.

* [x] I've tried this PR in combination with the aforementioned experiment in easy-split-multi-deposit. While everything compiles and all the tests succeed, Maven seems to take issue with this when running the `scala-maven-plugin`'s `doc-jar` goal. I've created an issue for that, so let's wait for that to play out a little bit more.
  * I've upgraded the `scala-maven-plugin` to the newly released `v3.4.6` and now the experiment in easy-split-multi-deposit succeeds.

@DANS-KNAW/easy for review