### PR TITLE
Next generation parent POMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <artifactId>dans-mvn-plugin-defaults</artifactId>
     <name>DANS Maven Project Plug-In Defaults</name>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         Defines the default configuration and version for plug-ins used in DANS projects.

--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,14 @@
     </parent>
     <artifactId>dans-mvn-plugin-defaults</artifactId>
     <name>DANS Maven Project Plug-In Defaults</name>
-    <version>4.0.0</version>
+    <version>4.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         Defines the default configuration and version for plug-ins used in DANS projects.
     </description>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>v4.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <!-- Build resources support -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-mvn-base</artifactId>
-        <version>2.0.0</version>
+        <version>4.0.0</version>
         <relativePath>../dans-mvn-base</relativePath>
     </parent>
     <artifactId>dans-mvn-plugin-defaults</artifactId>
     <name>DANS Maven Project Plug-In Defaults</name>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         Defines the default configuration and version for plug-ins used in DANS projects.
@@ -219,7 +219,7 @@
                     <version>${maven-antrun-plugin.version}</version>
                     <executions>
                         <execution>
-                            <phase>initialize</phase>
+                            <phase>generate-sources</phase>
                             <configuration>
                                 <target name="generate-rpm-scripts">
                                     <java classname="nl.knaw.dans.build.GenerateRpmScripts" failonerror="true">

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </scm>
     <properties>
         <!-- Build resources support -->
-        <dans-mvn-build-resources.version>3.2.0</dans-mvn-build-resources.version>
+        <dans-mvn-build-resources.version>4.0.0</dans-mvn-build-resources.version>
         <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
         <scala.version>2.12.3</scala.version>
         <scala.binary.version>2.12</scala.binary.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,14 @@
     </parent>
     <artifactId>dans-mvn-plugin-defaults</artifactId>
     <name>DANS Maven Project Plug-In Defaults</name>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <packaging>pom</packaging>
     <description>
         Defines the default configuration and version for plug-ins used in DANS projects.
     </description>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v4.0.0</tag>
     </scm>
     <properties>
         <!-- Build resources support -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
     <description>
         Defines the default configuration and version for plug-ins used in DANS projects.
     </description>
+    <scm>
+        <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
     <properties>
         <!-- Build resources support -->
         <dans-mvn-build-resources.version>3.2.0</dans-mvn-build-resources.version>


### PR DESCRIPTION
Part of next generation of parent POMs that add support for publishing RPMs to Nexus.

* Adds support for deploying RPMs to Nexus Yum repo, using `exec-maven-plugin`. This support can be activated (for non-POM projects) by a descendant by:
  * including the `exec-maven-plugin`
  * including the `maven-antrun-plugin`

